### PR TITLE
Accept pre-flattened u0 in Batched mode + GPU docs clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,34 @@ Load your preferred GPU backend and use GPU arrays:
 using LockstepODE
 using CUDA  # Or: AMDGPU, Metal, oneAPI
 
-# Convert initial conditions to GPU arrays
+# One CuArray per ODE (ergonomic input)
 u0s_gpu = [CuArray([1.0, 0.0]) for _ in 1:1000]
 
-# Use Batched mode for GPU
-prob = LockstepProblem{Batched}(lf, u0s_gpu, tspan, p)
+# Use Batched mode for GPU; PerIndex is the GPU-friendly layout
+prob = LockstepProblem{Batched}(lf, u0s_gpu, tspan, p; ordering=PerIndex())
 sol = solve(prob, Tsit5())  # Runs on GPU
+```
+
+The per-ODE `CuArray`s are concatenated into a single contiguous device array
+before integration. RHS evaluation is a single KernelAbstractions kernel launch
+over the flat state with one thread per ODE — no per-ODE kernel launches or
+vector-of-vectors in the hot path.
+
+**Memory ordering matters on GPU.** `PerODE` (the default) stores each ODE's
+state contiguously, which means adjacent threads read memory stride-`ode_size`
+apart — uncoalesced. `PerIndex` interleaves so that threads at the same
+ODE-step read adjacent addresses — coalesced. For small `ode_size` the penalty
+is modest; for larger per-ODE state it's the difference between good and bad
+bandwidth utilization. Prefer `PerIndex` for GPU.
+
+**Pre-flattened input for large N.** For big batches you can skip the N small
+device allocations and pass an already-flat state directly. Its length must be
+`num_odes * ode_size` and its byte layout must match the chosen `ordering`:
+
+```julia
+u0_flat = CUDA.zeros(Float64, lf.num_odes * lf.ode_size)
+# ... fill u0_flat in PerIndex layout ...
+prob = LockstepProblem{Batched}(lf, u0_flat, tspan, p; ordering=PerIndex())
 ```
 
 ## Per-ODE Callbacks
@@ -185,7 +207,7 @@ LockstepProblem{Batched}(lf, u0s, tspan, p=nothing; ordering=PerODE(), internal_
 
 1. **Choose the right mode**: Ensemble for control, Batched for performance
 2. **Use threading**: Keep `internal_threading=true` (default)
-3. **GPU for large N**: Use Batched mode with GPU arrays for N > 100
+3. **GPU for large N**: Use Batched mode with GPU arrays for N > 100. Pass `ordering=PerIndex()` for coalesced memory access; pass a pre-flattened `CuArray` of length `num_odes * ode_size` to avoid N small device allocations.
 4. **Type stability**: Ensure your ODE function is type-stable
 
 ## Contributing

--- a/src/batched.jl
+++ b/src/batched.jl
@@ -343,3 +343,14 @@ end
 function batch_u0s(u0s::Vector{<:AbstractVector})
     return batch_u0s(u0s, PerODE())
 end
+
+"""
+    batch_u0s(u0::AbstractVector{<:Number}, ::MemoryOrdering)
+
+Passthrough for a pre-flattened batch state. The caller is responsible for
+arranging bytes consistent with the chosen `MemoryOrdering` — no reordering
+is performed here.
+"""
+function batch_u0s(u0::AbstractVector{<:Number}, ::MemoryOrdering)
+    return u0
+end

--- a/src/batched.jl
+++ b/src/batched.jl
@@ -36,7 +36,7 @@ u0_batched = vcat([[1.0, 0.0, 0.0] for _ in 1:100]...)
 prob = ODEProblem(bf, u0_batched, (0.0, 10.0), nothing)
 ```
 """
-struct BatchedFunction{O<:MemoryOrdering, F, C, P}
+struct BatchedFunction{O <: MemoryOrdering, F, C, P}
     lf::LockstepFunction{F, C}
     ordering::O
     internal_threading::Bool
@@ -44,19 +44,19 @@ struct BatchedFunction{O<:MemoryOrdering, F, C, P}
 end
 
 function BatchedFunction(
-    lf::LockstepFunction{F, C},
-    params::P;
-    ordering::MemoryOrdering=PerODE(),
-    internal_threading::Bool=true
-) where {F, C, P}
+        lf::LockstepFunction{F, C},
+        params::P;
+        ordering::MemoryOrdering = PerODE(),
+        internal_threading::Bool = true
+    ) where {F, C, P}
     return BatchedFunction{typeof(ordering), F, C, P}(lf, ordering, internal_threading, params)
 end
 
 function BatchedFunction(
-    lf::LockstepFunction{F, C},
-    opts::BatchedOpts{O},
-    params::P
-) where {F, C, O, P}
+        lf::LockstepFunction{F, C},
+        opts::BatchedOpts{O},
+        params::P
+    ) where {F, C, O, P}
     return BatchedFunction{O, F, C, P}(lf, opts.ordering, opts.internal_threading, params)
 end
 
@@ -229,13 +229,7 @@ function create_lockstep_callbacks(bf::BatchedFunction)
     for i in 1:lf.num_odes
         cb = _get_ode_callback(lf.callbacks, i, lf.num_odes)
         isnothing(cb) && continue
-
-        if cb isa DiscreteCallback || cb isa ContinuousCallback
-            push!(wrapped_callbacks, _wrap_callback(cb, bf, i))
-        else
-            error("Unsupported callback type: $(typeof(cb)). " *
-                  "Only DiscreteCallback and ContinuousCallback are supported.")
-        end
+        _wrap_and_collect!(wrapped_callbacks, cb, bf, i)
     end
 
     if length(wrapped_callbacks) == 0
@@ -267,19 +261,49 @@ function _wrap_callback(cb::DiscreteCallback, bf::BatchedFunction, ode_idx::Int)
     return DiscreteCallback(
         _wrap_condition(bf, ode_idx, cb.condition),
         _wrap_affect(bf, ode_idx, cb.affect!);
-        save_positions=cb.save_positions
+        save_positions = cb.save_positions
     )
 end
 
 function _wrap_callback(cb::ContinuousCallback, bf::BatchedFunction, ode_idx::Int)
     wrapped_affect_neg! = isnothing(cb.affect_neg!) ? nothing :
-                          _wrap_affect(bf, ode_idx, cb.affect_neg!)
+        _wrap_affect(bf, ode_idx, cb.affect_neg!)
     return ContinuousCallback(
         _wrap_condition(bf, ode_idx, cb.condition),
         _wrap_affect(bf, ode_idx, cb.affect!),
         wrapped_affect_neg!;
-        save_positions=cb.save_positions
+        save_positions = cb.save_positions
     )
+end
+
+#==============================================================================#
+# Callback Collection Helper
+#==============================================================================#
+
+"""
+    _wrap_and_collect!(wrapped_callbacks, cb, bf::BatchedFunction, ode_idx::Int)
+
+Wrap a callback for the given ODE index and add to the collection.
+Handles DiscreteCallback, ContinuousCallback, and CallbackSet.
+"""
+function _wrap_and_collect!(wrapped_callbacks, cb::DiscreteCallback, bf::BatchedFunction, ode_idx::Int)
+    push!(wrapped_callbacks, _wrap_callback(cb, bf, ode_idx))
+    return nothing
+end
+
+function _wrap_and_collect!(wrapped_callbacks, cb::ContinuousCallback, bf::BatchedFunction, ode_idx::Int)
+    push!(wrapped_callbacks, _wrap_callback(cb, bf, ode_idx))
+    return nothing
+end
+
+function _wrap_and_collect!(wrapped_callbacks, cb::CallbackSet, bf::BatchedFunction, ode_idx::Int)
+    for discrete_cb in cb.discrete_callbacks
+        _wrap_and_collect!(wrapped_callbacks, discrete_cb, bf, ode_idx)
+    end
+    for continuous_cb in cb.continuous_callbacks
+        _wrap_and_collect!(wrapped_callbacks, continuous_cb, bf, ode_idx)
+    end
+    return nothing
 end
 
 #==============================================================================#

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -13,14 +13,16 @@ Problem type for batched ODE solving with mode-specific behavior.
 # Type Parameters
 - `M<:LockstepMode`: Execution mode (Ensemble or Batched)
 - `LF`: LockstepFunction type
-- `U`: Initial condition element type
+- `US<:AbstractVector`: Storage type for `u0s` (vector-of-vectors or pre-flattened batch)
 - `T`: Time type
 - `P`: Parameter element type
 - `Opts`: Mode-specific options type (Nothing for Ensemble, BatchedOpts for Batched)
 
 # Fields
 - `lf::LF`: LockstepFunction coordinator
-- `u0s::Vector{U}`: Initial conditions (one per ODE, normalized)
+- `u0s::US`: Initial conditions. Either a `Vector{<:AbstractVector}` of per-ODE states,
+  or (Batched mode only) a flat `AbstractVector{<:Number}` of length `num_odes * ode_size`
+  already arranged in the configured `MemoryOrdering`.
 - `tspan::Tuple{T, T}`: Time span
 - `ps::Vector{P}`: Parameters (one per ODE, normalized)
 - `opts::Opts`: Mode-specific options
@@ -59,9 +61,9 @@ prob_e = LockstepProblem{Ensemble}(lf, u0s, (0.0, 10.0), p)
 sol_e = solve(prob_e, Tsit5())
 ```
 """
-struct LockstepProblem{M<:LockstepMode, LF, U, T, P, Opts}
+struct LockstepProblem{M<:LockstepMode, LF, US<:AbstractVector, T, P, Opts}
     lf::LF
-    u0s::Vector{U}
+    u0s::US
     tspan::Tuple{T, T}
     ps::Vector{P}
     opts::Opts
@@ -100,14 +102,21 @@ function LockstepProblem{Ensemble}(
     tspan::Tuple,
     p = nothing
 ) where {F, C}
+    u0s isa AbstractVector{<:Number} && length(u0s) == lf.num_odes * lf.ode_size &&
+        throw(ArgumentError(
+            "Ensemble mode requires per-ODE initial conditions (a vector of vectors) " *
+            "or a single state vector to replicate. A pre-flattened batch of length " *
+            "num_odes * ode_size is only supported in Batched mode."
+        ))
+
     u0s_normalized = _normalize_u0s(u0s, lf.num_odes, lf.ode_size)
     ps_normalized = _normalize_params(p, lf.num_odes)
 
-    U = eltype(u0s_normalized)
+    US = typeof(u0s_normalized)
     T = promote_type(typeof(tspan[1]), typeof(tspan[2]))
     P = eltype(ps_normalized)
 
-    return LockstepProblem{Ensemble, typeof(lf), U, T, P, Nothing}(
+    return LockstepProblem{Ensemble, typeof(lf), US, T, P, Nothing}(
         lf,
         u0s_normalized,
         (T(tspan[1]), T(tspan[2])),
@@ -144,12 +153,12 @@ function LockstepProblem{Batched}(
     ps_normalized = _normalize_params(p, lf.num_odes)
     opts = BatchedOpts(; ordering=ordering, internal_threading=internal_threading)
 
-    U = eltype(u0s_normalized)
+    US = typeof(u0s_normalized)
     T = promote_type(typeof(tspan[1]), typeof(tspan[2]))
     P = eltype(ps_normalized)
     O = typeof(opts)
 
-    return LockstepProblem{Batched, typeof(lf), U, T, P, O}(
+    return LockstepProblem{Batched, typeof(lf), US, T, P, O}(
         lf,
         u0s_normalized,
         (T(tspan[1]), T(tspan[2])),
@@ -178,11 +187,21 @@ function _normalize_u0s(u0s::AbstractVector{<:AbstractVector}, num_odes::Int, od
 end
 
 function _normalize_u0s(u0::AbstractVector{<:Number}, num_odes::Int, ode_size::Int)
-    # Single u0 - replicate for all ODEs
-    length(u0) == ode_size || throw(ArgumentError(
-        "Expected state size $ode_size, got $(length(u0))"
-    ))
-    return [copy(u0) for _ in 1:num_odes]
+    n = length(u0)
+    if n == ode_size
+        # Single u0 - replicate for all ODEs
+        return [copy(u0) for _ in 1:num_odes]
+    elseif n == num_odes * ode_size
+        # Pre-flattened batch (Batched mode) - use as-is.
+        # Caller is responsible for arranging bytes consistent with the chosen MemoryOrdering.
+        return u0
+    else
+        throw(ArgumentError(
+            "u0 must have length $ode_size (single state, replicated across ODEs) or " *
+            "$(num_odes * ode_size) (pre-flattened batch of $num_odes ODEs × $ode_size state), " *
+            "got $n"
+        ))
+    end
 end
 
 """

--- a/test/problem.jl
+++ b/test/problem.jl
@@ -79,3 +79,111 @@ end
     @test_throws ArgumentError LockstepProblem(lf, [[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]], tspan)
 end
 
+@testitem "LockstepProblem pre-flattened u0 (Batched, PerODE)" begin
+    using LockstepODE
+    using OrdinaryDiffEq
+
+    function decay!(du, u, p, t)
+        du[1] = -p * u[1]
+        du[2] = -p * u[2]
+    end
+
+    num_odes = 4
+    ode_size = 2
+    lf = LockstepFunction(decay!, ode_size, num_odes)
+    ps = [0.1, 0.2, 0.3, 0.4]
+    tspan = (0.0, 1.0)
+
+    u0s_vov = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]
+    # PerODE layout: [u0s_vov[1]..., u0s_vov[2]..., ...]
+    u0_flat = vcat(u0s_vov...)
+
+    prob_vov = LockstepProblem{Batched}(lf, u0s_vov, tspan, ps; ordering=PerODE())
+    prob_flat = LockstepProblem{Batched}(lf, u0_flat, tspan, ps; ordering=PerODE())
+
+    # Flat storage roundtrips the input array
+    @test prob_flat.u0s === u0_flat
+    @test prob_flat.u0s isa AbstractVector{<:Number}
+    @test length(prob_flat.u0s) == num_odes * ode_size
+
+    sol_vov = solve(prob_vov, Tsit5())
+    sol_flat = solve(prob_flat, Tsit5())
+
+    for i in 1:num_odes
+        @test isapprox(sol_vov[i].u[end], sol_flat[i].u[end]; rtol=1e-8)
+    end
+end
+
+@testitem "LockstepProblem pre-flattened u0 (Batched, PerIndex)" begin
+    using LockstepODE
+    using OrdinaryDiffEq
+
+    function decay!(du, u, p, t)
+        du[1] = -p * u[1]
+        du[2] = -p * u[2]
+    end
+
+    num_odes = 3
+    ode_size = 2
+    lf = LockstepFunction(decay!, ode_size, num_odes)
+    ps = [0.5, 1.0, 2.0]
+    tspan = (0.0, 1.0)
+
+    u0s_vov = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    # PerIndex layout: [u1_ode1, u1_ode2, u1_ode3, u2_ode1, u2_ode2, u2_ode3]
+    u0_flat = Float64[
+        u0s_vov[1][1], u0s_vov[2][1], u0s_vov[3][1],
+        u0s_vov[1][2], u0s_vov[2][2], u0s_vov[3][2],
+    ]
+
+    prob_vov = LockstepProblem{Batched}(lf, u0s_vov, tspan, ps; ordering=PerIndex())
+    prob_flat = LockstepProblem{Batched}(lf, u0_flat, tspan, ps; ordering=PerIndex())
+
+    sol_vov = solve(prob_vov, Tsit5())
+    sol_flat = solve(prob_flat, Tsit5())
+
+    for i in 1:num_odes
+        @test isapprox(sol_vov[i].u[end], sol_flat[i].u[end]; rtol=1e-8)
+    end
+end
+
+@testitem "LockstepProblem pre-flattened u0 length validation" begin
+    using LockstepODE
+    using OrdinaryDiffEq
+
+    function decay!(du, u, p, t)
+        du[1] = -u[1]
+    end
+
+    lf = LockstepFunction(decay!, 1, 4)  # ode_size=1, num_odes=4; valid lengths: 1 or 4
+    tspan = (0.0, 1.0)
+
+    # length=2 is neither ode_size (1) nor num_odes*ode_size (4)
+    @test_throws ArgumentError LockstepProblem{Batched}(lf, [0.0, 1.0], tspan)
+    # length=3 likewise invalid
+    @test_throws ArgumentError LockstepProblem{Batched}(lf, [0.0, 1.0, 2.0], tspan)
+
+    # Boundary cases that must succeed
+    @test LockstepProblem{Batched}(lf, [1.0], tspan) isa LockstepProblem         # replicate
+    @test LockstepProblem{Batched}(lf, [1.0, 2.0, 3.0, 4.0], tspan) isa LockstepProblem  # flat
+end
+
+@testitem "LockstepProblem flat u0 rejected in Ensemble mode" begin
+    using LockstepODE
+    using OrdinaryDiffEq
+
+    function decay!(du, u, p, t)
+        du[1] = -u[1]
+        du[2] = -u[2]
+    end
+
+    lf = LockstepFunction(decay!, 2, 3)  # ode_size=2, num_odes=3 → flat length 6
+    tspan = (0.0, 1.0)
+
+    u0_flat = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    @test_throws ArgumentError LockstepProblem{Ensemble}(lf, u0_flat, tspan)
+
+    # Single-state replication (length=ode_size) still works in Ensemble mode
+    @test LockstepProblem{Ensemble}(lf, [1.0, 2.0], tspan) isa LockstepProblem
+end
+


### PR DESCRIPTION
## Summary

- **`feat`: accept a pre-flattened `u0` in Batched mode.** `LockstepProblem{Batched}(lf, u0_flat, tspan, p)` now accepts `u0_flat::AbstractVector{<:Number}` of length `num_odes * ode_size` directly, arranged in the configured `MemoryOrdering`. Single-state replication (length == `ode_size`) still works. Lets GPU users with large N skip N small device allocations. Ensemble mode throws `ArgumentError` on flat input and points at Batched mode.
- **`docs`: GPU Acceleration README rewrite.** Makes explicit that the per-ODE `CuArray` input is concatenated into a single contiguous device array before integration (one KernelAbstractions kernel launch, one thread per ODE — no per-ODE launches, no vector-of-vectors in the hot path). Example now uses `ordering=PerIndex()` with an explanation that `PerODE` is uncoalesced across threads on GPU. Documents the new flat-input path.
- **`refactor`(batched): CallbackSet support in callback wrapping.** `create_lockstep_callbacks` now dispatches through a `_wrap_and_collect!` helper that handles `DiscreteCallback`, `ContinuousCallback`, and `CallbackSet` (recursing into its discrete/continuous fields). Picks up pre-existing local WIP in `src/batched.jl`.

Motivated by a colleague asking whether the `[CuArray(...) for _ in 1:N]` pattern in the GPU README tanks performance. It doesn't (flatten + single KA kernel), but the README didn't make that clear and the default `PerODE` ordering is the wrong knob for GPU.

## Structural change

`LockstepProblem.u0s` field widened from `Vector{U}` to `US<:AbstractVector`. This changes the `LockstepProblem` type parameters (`U` → `US`). Non-breaking for all documented usage — the vec-of-vecs path stores `Vector{<:AbstractVector}` exactly as before.

## Verification

`julia --project -e 'using Pkg; Pkg.test()'` — 267/267 passing, including 16 new assertions across four `@testitem`s in `test/problem.jl` covering the PerODE flat path, PerIndex flat path, length validation, and Ensemble rejection.